### PR TITLE
fsadns: remove redundant reset of signal disposition

### DIFF
--- a/src/fsadns.c
+++ b/src/fsadns.c
@@ -496,7 +496,6 @@ fsadns_t *fsadns_make_resolver(async_t *async, unsigned max_parallel,
         return dns;
     }
     /* child */
-    signal(SIGTERM, SIG_DFL);
     action_1_perf(post_fork_cb);
     serve(fd[1], dns);
     FSTRACE(FSADNS_CHILD_EXIT, dns->uid);


### PR DESCRIPTION
unixkit_fork resets the disposition of all signals to default.