### PR TITLE
Optimize async_timer_start() and async_execute()

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ direct function call is more immediate, of course, but "backgrounding" tasks
 often has benefits: you can complete state transitions before the scheduled
 action is taken and multiple activities are interleaved fairly by the main loop.
 
-Tasks scheduled with `async_execute()` cannot be canceled.
+Like `async_timer_start()`, `async_execute()` returns a timer object.
+It is usually ignored but could be used by the application to cancel
+the pending action before it is executed.
 
 ## Notifications
 

--- a/include/async.h
+++ b/include/async.h
@@ -108,9 +108,11 @@ void async_event_cancel(async_event_t *event);
 void destroy_async_event(async_event_t *event);
 
 /*
- * Run a task from the main loop.
+ * Run a task from the main loop. The action takes place without
+ * delay. However, before it is put into effect, it can be canceled
+ * using async_timer_cancel().
  */
-void async_execute(async_t *async, action_1 action);
+async_timer_t *async_execute(async_t *async, action_1 action);
 
 /*
  * Deallocate object using fsfree() from the main loop. The caller

--- a/include/async_imp.h
+++ b/include/async_imp.h
@@ -1,6 +1,7 @@
 struct async {
     uint64_t uid;
     int poll_fd;
+    list_t *immediate;          /* of async_timer_t */
     priorq_t *timers;
     avl_tree_t *registrations;
     volatile bool quit;
@@ -15,6 +16,7 @@ struct async {
 struct async_timer {
     uint64_t expires;
     uint64_t seqno;
+    bool immediate;
     void *loc;
     action_1 action;
     void **stack_trace;      /* Where the timer was scheduled or NULL */

--- a/include/async_imp.h
+++ b/include/async_imp.h
@@ -1,7 +1,7 @@
 struct async {
     uint64_t uid;
     int poll_fd;
-    avl_tree_t *timers;
+    priorq_t *timers;
     avl_tree_t *registrations;
     volatile bool quit;
     int wakeup_fd;
@@ -12,13 +12,10 @@ struct async {
 #endif
 };
 
-typedef struct {
+struct async_timer {
     uint64_t expires;
     uint64_t seqno;
-} async_timer_key_t;
-
-struct async_timer {
-    async_timer_key_t key;
+    void *loc;
     action_1 action;
     void **stack_trace;      /* Where the timer was scheduled or NULL */
 };

--- a/test/SConscript
+++ b/test/SConscript
@@ -72,3 +72,6 @@ env.Program(
 
 env.Program('fsadns_test',
             [ 'fsadns_test.c' ])
+
+env.Program('timerperf',
+            [ 'timerperf.c' ])

--- a/test/timerperf.c
+++ b/test/timerperf.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <async/async.h>
+
+typedef struct {
+    async_t *async;
+} global_t;
+
+typedef struct {
+    global_t *g;
+    async_timer_t *timer;
+    bool last;
+} context_t;
+
+enum {
+    N = 10000000
+};
+
+static context_t *new_context(global_t *g, bool last)
+{
+    context_t *context = fsalloc(sizeof *context);
+    context->g = g;
+    context->last = last;
+    return context;
+}
+
+static void finish(context_t *context)
+{
+    async_t *async = context->g->async;
+    async_timer_cancel(async, context->timer);
+    if (context->last)
+        async_quit_loop(async);
+    fsfree(context);
+}
+
+static void start(context_t *context)
+{
+    async_t *async = context->g->async;
+    action_1 dummy_cb = { 0 };
+    context->timer =
+        async_timer_start(async, async_now(async) + ASYNC_H, dummy_cb);
+    async_execute(async, (action_1) { context, (act_1) finish });
+}
+
+static void kick_off(global_t *g)
+{
+    for (int i = 1; i < N; i++) {
+        action_1 start_cb = { new_context(g, false), (act_1) start };
+        async_execute(g->async, start_cb);
+    }
+    action_1 start_cb = { new_context(g, true), (act_1) start };
+    async_execute(g->async, start_cb);
+}
+
+int main()
+{
+    async_t *async = make_async();
+    global_t g = {
+        .async = async,
+    };
+    uint64_t t0 = async_now(async);
+    kick_off(&g);
+    while (async_loop(async) < 0)
+        if (errno != EINTR) {
+            perror("fsadns_test");
+            return EXIT_FAILURE;
+        }
+    async_flush(async, async_now(async) + ASYNC_MIN);
+    uint64_t t1 = async_now(async);
+    destroy_async(async);
+    printf("%g\n", (double) (t1 - t0) / ASYNC_S);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The new implementation replaces avl_tree_t with priorq_t for regular timers and list_t for timers created with async_execute(). Measurements indicate that the refactoring reduces timers' CPU consumption by about 50% with millions of concurrently scheduled timers.