### PR TITLE
Correct the semantics of async_loop_protected

### DIFF
--- a/test/asynctest-poll.c
+++ b/test/asynctest-poll.c
@@ -127,10 +127,8 @@ enum { MT_COUNT = 5 };
 
 static void mt_timeout(MULTITHREAD_CONTEXT *context)
 {
-    pthread_mutex_lock(&mutex);
     if (++context->counter == MT_COUNT)
         context->verdict = PASS;
-    pthread_mutex_unlock(&mutex);
 }
 
 static void *aux_thread(void *arg)


### PR DESCRIPTION
The barely-used async_loop_protected() function had unworkable locking semantics. Backward-compatibility is not an issue since the previous model didn't do any good to anybody. The only known application is fsadns.c in async itself.

Previously, async_loop_protected() reqlinquished the lock during callbacks. Now, the lock is relinquished only around epoll_wait(). Callbacks may temporarily unlock the lock, but there usually shouldn't be a need.