### PR TITLE
Fix build on macOS 11

### DIFF
--- a/src/tcp_connection.c
+++ b/src/tcp_connection.c
@@ -470,7 +470,7 @@ static void replenish_outbuf(tcp_conn_t *conn)
     conn->outcount = count;
 }
 
-#ifdef SO_NOSIGPIPE
+#ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
 #endif
 #ifndef CMSG_ALIGN


### PR DESCRIPTION
macOS 11 defines both "MSG_NOSIGNAL" and "SO_NOSIGPIPE".