### PR TITLE
jsonthreader: fix termination

### DIFF
--- a/src/jsonthreader.c
+++ b/src/jsonthreader.c
@@ -120,6 +120,8 @@ static void serve(void *obj)
         } else {
             FSTRACE(ASYNC_JSONTHREADER_SERVE_FAIL);
             async_quit_loop(bh->async);
+            unlock(bh);
+            return;
         }
     }
 }


### PR DESCRIPTION
In the multithreaded version, the missing return causes the threader
process to enter an infinite loop on EOF or fatal error from parent.