### PR TITLE
Use %A instead of %B to trace data dumps

### DIFF
--- a/src/base64decoder.c
+++ b/src/base64decoder.c
@@ -47,7 +47,7 @@ static int8_t map(base64decoder_t *decoder, uint8_t c)
     return -1;
 }
 
-FSTRACE_DECL(ASYNC_BASE64DECODER_READ_INPUT_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_BASE64DECODER_READ_INPUT_DUMP, "UID=%64u DATA=%A");
 
 static ssize_t decoder_read(base64decoder_t *decoder, void *buf, size_t count)
 {
@@ -80,7 +80,7 @@ static ssize_t decoder_read(base64decoder_t *decoder, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_BASE64DECODER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_BASE64DECODER_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_BASE64DECODER_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t base64decoder_read(base64decoder_t *decoder, void *buf, size_t count)
 {

--- a/src/base64encoder.c
+++ b/src/base64encoder.c
@@ -142,7 +142,7 @@ static ssize_t do_read(base64encoder_t *encoder, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_BASE64ENCODER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_BASE64ENCODER_READ_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_BASE64ENCODER_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t base64encoder_read(base64encoder_t *encoder, void *buf, size_t count)
 {

--- a/src/blobstream.c
+++ b/src/blobstream.c
@@ -25,7 +25,7 @@ size_t blobstream_remaining(blobstream_t *blobstr)
 }
 
 FSTRACE_DECL(ASYNC_BLOBSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_BLOBSTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_BLOBSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t blobstream_read(blobstream_t *blobstr, void *buf, size_t count)
 {
@@ -115,7 +115,7 @@ static blobstream_t *make_blobstream(async_t *async, uint64_t uid,
 }
 
 FSTRACE_DECL(ASYNC_BLOBSTREAM_OPEN, "UID=%64u ASYNC=%p BLOB-SIZE=%z");
-FSTRACE_DECL(ASYNC_BLOBSTREAM_BLOB_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_BLOBSTREAM_BLOB_DUMP, "UID=%64u DATA=%A");
 
 blobstream_t *open_blobstream(async_t *async, const void *blob, size_t count)
 {

--- a/src/blockingstream.c
+++ b/src/blockingstream.c
@@ -17,7 +17,7 @@ struct blockingstream {
 };
 
 FSTRACE_DECL(ASYNC_BLOCKINGSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_BLOCKINGSTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_BLOCKINGSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t blockingstream_read(blockingstream_t *blockingstr, void *buf,
                             size_t count)

--- a/src/chunkdecoder.c
+++ b/src/chunkdecoder.c
@@ -298,7 +298,7 @@ static ssize_t read_errored(chunkdecoder_t *decoder, void *buf, size_t size)
 }
 
 FSTRACE_DECL(ASYNC_CHUNKDECODER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_CHUNKDECODER_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_CHUNKDECODER_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t chunkdecoder_read(chunkdecoder_t *decoder, void *buf, size_t size)
 {

--- a/src/chunkencoder.c
+++ b/src/chunkencoder.c
@@ -77,7 +77,7 @@ static ssize_t do_read(chunkencoder_t *encoder, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_CHUNKENCODER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_CHUNKENCODER_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_CHUNKENCODER_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t chunkencoder_read(chunkencoder_t *encoder, void *buf, size_t count)
 {

--- a/src/clobberstream.c
+++ b/src/clobberstream.c
@@ -37,7 +37,7 @@ static ssize_t do_read(clobberstream_t *clstr, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_CLOBBERSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_CLOBBERSTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_CLOBBERSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t clobberstream_read(clobberstream_t *clstr, void *buf, size_t count)
 {

--- a/src/deserializer.c
+++ b/src/deserializer.c
@@ -89,7 +89,7 @@ static ssize_t do_read(deserializer_t *deserializer, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_DESERIALIZER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_DESERIALIZER_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_DESERIALIZER_READ_DUMP, "UID=%64u DATA=%A");
 
 static ssize_t frame_read(void *obj, void *buf, size_t count)
 {

--- a/src/farewellstream.c
+++ b/src/farewellstream.c
@@ -18,7 +18,7 @@ struct farewellstream {
 };
 
 FSTRACE_DECL(ASYNC_FAREWELLSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_FAREWELLSTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_FAREWELLSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t farewellstream_read(farewellstream_t *fwstr, void *buf, size_t count)
 {

--- a/src/iconvstream.c
+++ b/src/iconvstream.c
@@ -75,7 +75,7 @@ static void set_state(iconvstream_t *stream, iconvstream_state_t state)
     stream->state = state;
 }
 
-FSTRACE_DECL(ASYNC_ICONVSTREAM_READ_INPUT_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_ICONVSTREAM_READ_INPUT_DUMP, "UID=%64u DATA=%A");
 
 static ssize_t consume_outbuf(iconvstream_t *stream, void *buf, size_t count)
 {
@@ -156,7 +156,7 @@ static ssize_t stream_read(iconvstream_t *stream, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_ICONVSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_ICONVSTREAM_READ_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_ICONVSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t iconvstream_read(iconvstream_t *stream, void *buf, size_t count)
 {

--- a/src/jsondecoder.c
+++ b/src/jsondecoder.c
@@ -41,7 +41,7 @@ static ssize_t read_frame(void *obj, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_JSONDECODER_RECEIVE_SYNTAX_ERROR, "UID=%64u");
-FSTRACE_DECL(ASYNC_JSONDECODER_RECEIVE_INPUT_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_JSONDECODER_RECEIVE_INPUT_DUMP, "UID=%64u DATA=%A");
 
 static json_thing_t *do_receive(jsondecoder_t *decoder)
 {

--- a/src/jsonencoder.c
+++ b/src/jsonencoder.c
@@ -39,7 +39,7 @@ size_t jsonencoder_size(jsonencoder_t *encoder)
 }
 
 FSTRACE_DECL(ASYNC_JSONENCODER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_JSONENCODER_READ_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_JSONENCODER_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t jsonencoder_read(jsonencoder_t *encoder, void *buf, size_t count)
 {

--- a/src/jsonyield.c
+++ b/src/jsonyield.c
@@ -83,7 +83,7 @@ static ssize_t read_frame(void *obj, void *buf, size_t count)
     return bytestream_1_read(*stream, buf, count);
 }
 
-FSTRACE_DECL(ASYNC_JSONYIELD_INPUT_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_JSONYIELD_INPUT_DUMP, "UID=%64u DATA=%A");
 
 static json_thing_t *do_receive(jsonyield_t *yield)
 {

--- a/src/multipartdecoder.c
+++ b/src/multipartdecoder.c
@@ -284,7 +284,7 @@ static void read_symbol(multipartdecoder_t *decoder, char c)
     }
 }
 
-FSTRACE_DECL(ASYNC_MULTIPARTDECODER_INPUT_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_MULTIPARTDECODER_INPUT_DUMP, "UID=%64u DATA=%A");
 
 static ssize_t do_read(multipartdecoder_t *decoder, void *buf, size_t size)
 {
@@ -359,7 +359,7 @@ static ssize_t do_read(multipartdecoder_t *decoder, void *buf, size_t size)
 }
 
 FSTRACE_DECL(ASYNC_MULTIPARTDECODER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_MULTIPARTDECODER_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_MULTIPARTDECODER_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t multipartdecoder_read(multipartdecoder_t *decoder, void *buf,
                               size_t size)

--- a/src/naivedecoder.c
+++ b/src/naivedecoder.c
@@ -94,7 +94,7 @@ static ssize_t do_read(naivedecoder_t *decoder, void *buf, size_t size)
 }
 
 FSTRACE_DECL(ASYNC_NAIVEDECODER_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_NAIVEDECODER_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_NAIVEDECODER_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t naivedecoder_read(naivedecoder_t *decoder, void *buf, size_t size)
 {

--- a/src/nicestream.c
+++ b/src/nicestream.c
@@ -29,7 +29,7 @@ static void retry(nicestream_t *nice)
 
 FSTRACE_DECL(ASYNC_NICESTREAM_BACK_OFF, "UID=%64u WANT=%z");
 FSTRACE_DECL(ASYNC_NICESTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_NICESTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_NICESTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t nicestream_read(nicestream_t *nice, void *buf, size_t count)
 {

--- a/src/pacerstream.c
+++ b/src/pacerstream.c
@@ -33,7 +33,7 @@ static void retry(pacerstream_t *pacer)
 
 FSTRACE_DECL(ASYNC_PACERSTREAM_READ_POSTPONE, "UID=%64u WANT=%z");
 FSTRACE_DECL(ASYNC_PACERSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_PACERSTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_PACERSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t pacerstream_read(pacerstream_t *pacer, void *buf, size_t count)
 {

--- a/src/pausestream.c
+++ b/src/pausestream.c
@@ -24,7 +24,7 @@ FSTRACE_DECL(ASYNC_PAUSESTREAM_READ_PAUSED,
              "UID=%64u WANT=%z LIMIT=%64u CURSOR=%64u");
 FSTRACE_DECL(ASYNC_PAUSESTREAM_READ,
              "UID=%64u WANT=%z GOT=%z CURSOR=%64u ERRNO=%e");
-FSTRACE_DECL(ASYNC_PAUSESTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_PAUSESTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t pausestream_read(pausestream_t *pausestr, void *buf, size_t count)
 {

--- a/src/pipestream.c
+++ b/src/pipestream.c
@@ -18,7 +18,7 @@ struct pipestream {
 };
 
 FSTRACE_DECL(ASYNC_PIPESTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_PIPESTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_PIPESTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t pipestream_read(pipestream_t *pipestr, void *buf, size_t count)
 {

--- a/src/probestream.c
+++ b/src/probestream.c
@@ -46,7 +46,7 @@ static void _unregister_callback(void *obj)
 }
 
 FSTRACE_DECL(ASYNC_PROBESTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_PROBESTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_PROBESTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t probestream_read(probestream_t *probestr, void *buf, size_t count)
 {

--- a/src/queuestream.c
+++ b/src/queuestream.c
@@ -188,7 +188,7 @@ static ssize_t do_read(queuestream_t *qstr, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_QUEUESTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_QUEUESTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_QUEUESTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t queuestream_read(queuestream_t *qstr, void *buf, size_t count)
 {

--- a/src/reservoir.c
+++ b/src/reservoir.c
@@ -104,7 +104,7 @@ bool reservoir_fill(reservoir_t *reservoir)
 }
 
 FSTRACE_DECL(ASYNC_RESERVOIR_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_RESERVOIR_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_RESERVOIR_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t reservoir_read(reservoir_t *reservoir, void *buf, size_t count)
 {

--- a/src/stringstream.c
+++ b/src/stringstream.c
@@ -18,7 +18,7 @@ struct stringstream {
 };
 
 FSTRACE_DECL(ASYNC_STRINGSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_STRINGSTREAM_READ_DUMP, "UID=%64u TEXT=%A");
+FSTRACE_DECL(ASYNC_STRINGSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t stringstream_read(stringstream_t *strstr, void *buf, size_t count)
 {

--- a/src/substream.c
+++ b/src/substream.c
@@ -69,7 +69,7 @@ static ssize_t do_read(substream_t *substr, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_SUBSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_SUBSTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_SUBSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t substream_read(substream_t *substr, void *buf, size_t count)
 {

--- a/src/switchstream.c
+++ b/src/switchstream.c
@@ -17,7 +17,7 @@ struct switchstream {
 };
 
 FSTRACE_DECL(ASYNC_SWITCHSTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_SWITCHSTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_SWITCHSTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t switchstream_read(switchstream_t *swstr, void *buf, size_t count)
 {

--- a/src/tcp_connection.c
+++ b/src/tcp_connection.c
@@ -101,7 +101,7 @@ static size_t ancillary_data_info(struct cmsghdr *cp, int *level, int *type)
 
 FSTRACE_DECL(ASYNC_TCP_RECEIVE_ANCILLARY, "UID=%64u SIZE=%z");
 FSTRACE_DECL(ASYNC_TCP_RECEIVE_ANCILLARY_FD, "UID=%64u FD=%d");
-FSTRACE_DECL(ASYNC_TCP_RECEIVE_ANCILLARY_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_RECEIVE_ANCILLARY_DUMP, "UID=%64u DATA=%A");
 
 static void receive_ancillary_data(tcp_conn_t *conn, struct cmsghdr *cp)
 {
@@ -161,7 +161,7 @@ static ssize_t receive(tcp_conn_t *conn, void *buf, size_t size)
 
 FSTRACE_DECL(ASYNC_TCP_READ_INACTIVE, "UID=%64u WANT=%z");
 FSTRACE_DECL(ASYNC_TCP_READ, "UID=%64u WANT=%z GOT=%z");
-FSTRACE_DECL(ASYNC_TCP_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_READ_DUMP, "UID=%64u DATA=%A");
 FSTRACE_DECL(ASYNC_TCP_READ_EOF, "UID=%64u WANT=%z");
 FSTRACE_DECL(ASYNC_TCP_READ_FAILED, "UID=%64u WANT=%z ERRNO=%e");
 FSTRACE_DECL(ASYNC_TCP_READ_CONNECTING, "UID=%64u WANT=%z");
@@ -438,7 +438,7 @@ static void schedule_user_probe(tcp_conn_t *conn);
 FSTRACE_DECL(ASYNC_TCP_REPLENISH_FAIL, "UID=%64u ERRNO=%e");
 FSTRACE_DECL(ASYNC_TCP_REPLENISH_EOF, "UID=%64u");
 FSTRACE_DECL(ASYNC_TCP_REPLENISH, "UID=%64u GOT=%z");
-FSTRACE_DECL(ASYNC_TCP_REPLENISH_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_REPLENISH_DUMP, "UID=%64u DATA=%A");
 
 static void replenish_outbuf(tcp_conn_t *conn)
 {
@@ -480,12 +480,12 @@ static void replenish_outbuf(tcp_conn_t *conn)
 
 FSTRACE_DECL(ASYNC_TCP_SEND_FAIL, "UID=%64u WANT=%z ERRNO=%e");
 FSTRACE_DECL(ASYNC_TCP_SEND, "UID=%64u WANT=%z GOT=%z");
-FSTRACE_DECL(ASYNC_TCP_SEND_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_SEND_DUMP, "UID=%64u DATA=%A");
 FSTRACE_DECL(ASYNC_TCP_SENDMSG_ANCILLARY, "UID=%64u SIZE=%z");
-FSTRACE_DECL(ASYNC_TCP_SENDMSG_ANCILLARY_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_SENDMSG_ANCILLARY_DUMP, "UID=%64u DATA=%A");
 FSTRACE_DECL(ASYNC_TCP_SENDMSG_FAIL, "UID=%64u WANT=%z ERRNO=%e");
 FSTRACE_DECL(ASYNC_TCP_SENDMSG, "UID=%64u WANT=%z GOT=%z");
-FSTRACE_DECL(ASYNC_TCP_SENDMSG_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_SENDMSG_DUMP, "UID=%64u DATA=%A");
 
 static ssize_t transmit(tcp_conn_t *conn, size_t remaining)
 {
@@ -927,7 +927,7 @@ ssize_t tcp_peek_ancillary_data(tcp_conn_t *conn, int *level, int *type)
 
 FSTRACE_DECL(ASYNC_TCP_RECV_ANCILLARY_FAIL, "UID=%64u ERRNO=%e");
 FSTRACE_DECL(ASYNC_TCP_RECV_ANCILLARY, "UID=%64u SIZE=%z");
-FSTRACE_DECL(ASYNC_TCP_RECV_ANCILLARY_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_RECV_ANCILLARY_DUMP, "UID=%64u DATA=%A");
 
 ssize_t tcp_recv_ancillary_data(tcp_conn_t *conn, void *buf, size_t size)
 {
@@ -1003,7 +1003,7 @@ list_t *tcp_peek_received_fds(tcp_conn_t *conn)
 }
 
 FSTRACE_DECL(ASYNC_TCP_SEND_ANCILLARY, "UID=%64u SIZE=%z");
-FSTRACE_DECL(ASYNC_TCP_SEND_ANCILLARY_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TCP_SEND_ANCILLARY_DUMP, "UID=%64u DATA=%A");
 
 ssize_t tcp_send_ancillary_data(tcp_conn_t *conn, int level, int type,
                                 const void *buf, size_t size)

--- a/src/tricklestream.c
+++ b/src/tricklestream.c
@@ -53,7 +53,7 @@ static ssize_t do_read(tricklestream_t *trickle, void *buf, size_t count)
 }
 
 FSTRACE_DECL(ASYNC_TRICKLESTREAM_READ, "UID=%64u WANT=%z GOT=%z ERRNO=%e");
-FSTRACE_DECL(ASYNC_TRICKLESTREAM_READ_DUMP, "UID=%64u DATA=%B");
+FSTRACE_DECL(ASYNC_TRICKLESTREAM_READ_DUMP, "UID=%64u DATA=%A");
 
 ssize_t tricklestream_read(tricklestream_t *trickle, void *buf, size_t count)
 {


### PR DESCRIPTION
Using %A displays textual data legibly while not being bad for binary data, either.