### PR TITLE
Fix broken ancillary_data semantics in tcp_connection.c

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -54,10 +54,8 @@ TARGET_FLAGS = {
 def construct():
     ccflags = (
         ' -g -O2 -Wall -Wextra -Werror '
-        '-Wno-null-pointer-arithmetic '
         '-Wno-sign-compare '
-        '-Wno-unknown-warning-option '
-        '-Wno-unused-label '
+        '-Wno-maybe-uninitialized '
         '-Wno-unused-parameter '
     )
     prefix = ARGUMENTS.get('prefix', '/usr/local')


### PR DESCRIPTION
tcp_connection.c "thought" it could pack an arbitrary amount of ancillary data in sendmsg(2). The unix(7) man page gives strict limitations, though, which are violated. Slightly simplified, you're allowed to send one ancillary piece of information at a time.

The wrong assumption led to sendmsg(2) returning with EINVAL in real-life use.

The change is de-facto backward-compatible with all extant (and imaginable) use cases.