### PR TITLE
Set up wakeup pipe for async_poll()

### DIFF
--- a/include/async_imp.h
+++ b/include/async_imp.h
@@ -5,7 +5,7 @@ struct async {
     priorq_t *timers;
     avl_tree_t *registrations;
     volatile bool quit;
-    int wakeup_fd;
+    int wakeup_fd[2];
     list_t *wounded_objects;
     uint64_t recent;
 #ifdef __MACH__


### PR DESCRIPTION
The wakeup_fd mechanism is not used with async_loop() because it is redundant. It is used with async_loop_protected() because external async library calls (async_execute(), in particular) requires an epoll trigger.

When an external main loop is used, async_poll() must be triggered for similar reasons and the wakeup_fd mechanism must be in effect. This PR adds that support in a transparent and robust manner: the wakeup_fd mechanism is activated when needed without any external involvement.

(This whole scheme should be simpler using a timer fd. Unfortunately, timer fds are not available on MacOS.)