### PR TITLE
Fix wrong trace name in F_SETFL error path

### DIFF
--- a/src/tcp_connection.c
+++ b/src/tcp_connection.c
@@ -874,7 +874,7 @@ tcp_conn_t *tcp_connect(async_t *async, const struct sockaddr *from,
         return NULL;
     }
     if (fcntl(connfd, F_SETFL, status | O_NONBLOCK) < 0) {
-        FSTRACE(ASYNC_TCP_CONNECT_GETFL_FAIL, uid);
+        FSTRACE(ASYNC_TCP_CONNECT_SETFL_FAIL, uid);
         int err = errno;
         close(connfd);
         errno = err;


### PR DESCRIPTION
The F_SETFL failure at tcp_connect was tracing
ASYNC_TCP_CONNECT_GETFL_FAIL instead of the correctly declared ASYNC_TCP_CONNECT_SETFL_FAIL.