### PR TITLE
Fix EAI_OVERFLOW trace string

### DIFF
--- a/src/fsadns.c
+++ b/src/fsadns.c
@@ -148,7 +148,7 @@ static const char *trace_getaddrinfo_error(void *perror)
         case EAI_MEMORY:
             return "EAI_MEMORY";
         case EAI_OVERFLOW:
-            return "EAI_MEMORY";
+            return "EAI_OVERFLOW";
 #ifdef EAI_NODATA
         case EAI_NODATA:
             return "EAI_NODATA";


### PR DESCRIPTION
The EAI_OVERFLOW case was returning "EAI_MEMORY" due to a copy-paste error.