### PR TITLE
Clarify subprocess.h documentation

### DIFF
--- a/include/subprocess.h
+++ b/include/subprocess.h
@@ -16,30 +16,47 @@ typedef struct subprocess subprocess_t;
 /*
  * Create a subprocess using fork(2).
  *
- * The given post-fork callback is run in the subprocess
- * synchronously, i.e., not from the main loop of the given async
- * object, and can be used to execute a program with exec(3). If the
- * subprocess uses the given async object, the behaviour is undefined.
- * If the subprocess uses exit(3) to terminate, the behaviour is
- * undefined. This function acquires ownership of the list of file
- * descriptors argument.
+ * The post-fork callback is invoked in the child process after fork,
+ * concurrently with the parent. It is typically
+ * used to call exec(3). If the callback returns without calling exec,
+ * the child calls _exit(1). The child must not use the given async
+ * object (behaviour is undefined) or call exit(3) (behaviour is
+ * undefined).
+ *
+ * All file descriptors except those listed in keep_fds are closed in
+ * the child process. This function takes ownership of keep_fds and
+ * appends the stdout/stderr pipe endpoints to it internally, so the
+ * caller must not include those.
  */
 subprocess_t *open_subprocess(async_t *async, list_t *keep_fds,
                               bool capture_stdout, bool capture_stderr,
                               action_1 post_fork_cb);
 
+/*
+ * Close the subprocess object and any captured streams that have not
+ * been released. Does not kill or wait for the child process; call
+ * subprocess_wait first to avoid leaving a zombie.
+ */
 void subprocess_close(subprocess_t *subprocess);
 
 /*
- * Return the captured subprocess output or error stream and move its
- * ownership to the caller.
+ * Transfer ownership of the captured stdout (or stderr) stream to the
+ * caller. After release, the stream is the caller's responsibility to
+ * close, and subprocess_close will no longer affect it. Returns a dry
+ * (empty) stream if capture was not requested or the stream was
+ * already released.
  */
 bytestream_1 subprocess_release_stdout(subprocess_t *subprocess);
 bytestream_1 subprocess_release_stderr(subprocess_t *subprocess);
 pid_t subprocess_get_pid(subprocess_t *subprocess);
+
 /*
- * A negative exit status value -N indicates that the subprocess
- * terminated due to receipt of signal N.
+ * Wait for the child process to terminate and return its exit status.
+ * A negative value -N indicates termination by signal N.
+ *
+ * The intended use is to call this after EOF has been read from the
+ * captured stdout/stderr streams, by which time the well-behaved
+ * child process has exited or is about to.
  */
 bool subprocess_wait(subprocess_t *subprocess, int *exit_status);
 


### PR DESCRIPTION
- Explain that the post-fork callback runs in the child process concurrently with the parent, and that _exit(1) is called if it returns
- Document that keep_fds is consumed and that internal pipe fds are appended automatically
- Note that subprocess_close does not kill or wait for the child; warn to call subprocess_wait first to avoid zombies
- Describe release semantics: transfers ownership, subsequent close will not affect the released stream
- Clarify intended use of subprocess_wait: call after EOF on captured streams