### PR TITLE
Add dryyield

### DIFF
--- a/components/async/SConscript
+++ b/components/async/SConscript
@@ -20,6 +20,7 @@ include = env.Install(
         '#include/clobberstream.h',
         '#include/concatstream.h',
         '#include/drystream.h',
+        '#include/dryyield.h',
         '#include/emptystream.h',
         '#include/errorstream.h',
         '#include/farewellstream.h',

--- a/include/dryyield.h
+++ b/include/dryyield.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "yield_1.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * The dry stream's receive method always returns NULL/EAGAIN (no data yet).
+ */
+extern const yield_1 dryyield;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/SConscript
+++ b/src/SConscript
@@ -35,6 +35,7 @@ env.StaticLibrary(
         'concatstream.c',
         'deserializer.c',
         'drystream.c',
+        'dryyield.c',
         'emptystream.c',
         'errorstream.c',
         'farewellstream.c',

--- a/src/base64encoder.c
+++ b/src/base64encoder.c
@@ -23,7 +23,7 @@ struct base64encoder {
     unsigned bits;
 };
 
-static char BASE64MAP[62] =
+static char BASE64MAP[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
 FSTRACE_DECL(ASYNC_BASE64ENCODER_CREATE, "UID=%64u PTR=%p ASYNC=%p STREAM=%p");

--- a/src/dryyield.c
+++ b/src/dryyield.c
@@ -1,0 +1,35 @@
+#include "dryyield.h"
+
+#include <errno.h>
+#include <stdio.h>
+
+#include <fstrace.h>
+
+#include "async_version.h"
+
+FSTRACE_DECL(ASYNC_DRYYIELD_RECEIVE, "ERRNO=%e");
+
+static void *_receive(void *obj)
+{
+    errno = EAGAIN;
+    FSTRACE(ASYNC_DRYYIELD_RECEIVE);
+    return NULL;
+}
+
+static void _close(void *obj) {}
+
+static void _register_callback(void *obj, action_1 action) {}
+
+static void _unregister_callback(void *obj) {}
+
+static const struct yield_1_vt dryyield_vt = {
+    .receive = _receive,
+    .close = _close,
+    .register_callback = _register_callback,
+    .unregister_callback = _unregister_callback,
+};
+
+const yield_1 dryyield = {
+    .obj = NULL,
+    .vt = &dryyield_vt,
+};


### PR DESCRIPTION
Analogous to drystream, dryyield is a special yield whose receive method always returns with NULL and EAGAIN.